### PR TITLE
Change "Taiwan, Province of China" to "Taiwan"

### DIFF
--- a/lib/country_select.rb
+++ b/lib/country_select.rb
@@ -57,7 +57,7 @@ module ActionView
         "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "South Africa",
         "South Georgia and the South Sandwich Islands", "Spain", "Sri Lanka", "Sudan", "Suriname",
         "Svalbard and Jan Mayen", "Swaziland", "Sweden", "Switzerland", "Syrian Arab Republic",
-        "Taiwan, Province of China", "Tajikistan", "Tanzania, United Republic of", "Thailand", "Timor-Leste",
+        "Taiwan", "Tajikistan", "Tanzania, United Republic of", "Thailand", "Timor-Leste",
         "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan",
         "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ukraine", "United Arab Emirates", "United Kingdom",
         "United States", "United States Minor Outlying Islands", "Uruguay", "Uzbekistan", "Vanuatu", "Venezuela",


### PR DESCRIPTION
Let's just call it Taiwan.  Some customers have complained about their
country being listed as a province of China.

More background:
http://en.wikipedia.org/wiki/Taiwan,_China
